### PR TITLE
Add setup target to install backend and frontend deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # Bear Detection System - Makefile
 
-.PHONY: help dev dev-docker stop stop-docker clean logs seed test build
+.PHONY: help setup dev dev-docker stop stop-docker clean logs seed test build
 
 # デフォルトターゲット
 help:
 	@echo "🐻 クマ検出警報システム"
 	@echo ""
 	@echo "利用可能なコマンド:"
+	@echo "  make setup      - バックエンド/フロントエンドの依存関係をインストール"
 	@echo "  make dev        - ローカル開発環境を起動（Docker不要）"
 	@echo "  make stop       - ローカル開発環境を停止"
 	@echo "  make dev-docker - Docker開発環境を起動"
@@ -23,6 +24,15 @@ help:
 dev:
 	@chmod +x start-local.sh
 	@./start-local.sh
+
+# セットアップ（ローカル）
+setup:
+	@echo "🔧 バックエンド依存関係をインストール中..."
+	@test -d backend/venv || python3 -m venv backend/venv
+	@. backend/venv/bin/activate && pip install -r backend/requirements.txt
+	@echo "🎨 フロントエンド依存関係をインストール中..."
+	@cd frontend && npm install
+	@echo "✅ セットアップ完了"
 
 # Docker開発環境起動
 dev-docker:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 ### 方法1: Makefileを使用（推奨）
 
 ```bash
+# 依存関係のセットアップ（初回）
+make setup
+
 # ローカル開発環境を起動（Docker不要）
 make dev
 
@@ -133,6 +136,7 @@ make seed
 
 ```bash
 # ローカル開発（Docker不要）
+make setup        # 依存関係をセットアップ
 make dev          # ローカル開発環境を起動
 make stop         # ローカル開発環境を停止
 


### PR DESCRIPTION
Summary
- add a `make setup` target that creates/uses the backend virtualenv, installs Python requirements, and runs `npm install` for the frontend
- document the new setup step in the README so developers know to run it before starting local development

Testing
- Not run (not requested)