### PR TITLE
Add camera placement click mode

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,7 @@ import { CameraRegisterPanel } from '@/features/camera-register';
 import { AlertPanel } from '@/widgets/alert-panel';
 import { X, Upload, Bell, RefreshCw, Camera, LogOut, Settings } from 'lucide-react';
 import { useAuth } from '@/shared/providers/AuthProvider';
-import type { Alert, DisplayMode, Sighting } from '@/shared/types';
+import type { Alert, DisplayMode, LatLng, Sighting } from '@/shared/types';
 
 // SSRを無効化してMapViewを読み込む（Leafletはクライアントサイドのみ）
 const MapView = dynamic(
@@ -24,7 +24,6 @@ const MapView = dynamic(
 );
 
 type ActivePanel = 'upload' | 'alerts' | 'camera' | null;
-type CameraPlacementLocation = { lat: number; lng: number };
 
 export default function HomePage() {
   const { user, loading, logout } = useAuth();
@@ -35,7 +34,7 @@ export default function HomePage() {
   const [nearbyBounds, setNearbyBounds] = useState<string | null>(null);
   const [isCameraPlacementMode, setIsCameraPlacementMode] = useState(false);
   const [selectedCameraLocation, setSelectedCameraLocation] =
-    useState<CameraPlacementLocation | null>(null);
+    useState<LatLng | null>(null);
 
   // 未認証の場合はログインページにリダイレクト
   useEffect(() => {

--- a/frontend/src/features/camera-register/ui/CameraRegisterPanel.tsx
+++ b/frontend/src/features/camera-register/ui/CameraRegisterPanel.tsx
@@ -3,14 +3,12 @@
 import React, { useState, useEffect } from 'react';
 import { MapPin, Camera, Check, AlertCircle, Loader2 } from 'lucide-react';
 import { createCamera, getCameras } from '@/shared/api';
-import type { Camera as CameraType } from '@/shared/types';
-
-type CameraPlacementLocation = { lat: number; lng: number };
+import type { Camera as CameraType, LatLng } from '@/shared/types';
 
 interface CameraRegisterPanelProps {
   onRegisterComplete?: () => void;
   placementMode: boolean;
-  selectedLocation: CameraPlacementLocation | null;
+  selectedLocation: LatLng | null;
   onPlacementModeChange: (enabled: boolean) => void;
   onClearSelectedLocation: () => void;
 }
@@ -31,6 +29,12 @@ export const CameraRegisterPanel: React.FC<CameraRegisterPanelProps> = ({
   const [success, setSuccess] = useState(false);
   const [cameras, setCameras] = useState<CameraType[]>([]);
   const [isLoadingCameras, setIsLoadingCameras] = useState(true);
+
+  const clearSelectedLocationInputs = () => {
+    onClearSelectedLocation();
+    setLatitude('');
+    setLongitude('');
+  };
 
   // カメラ一覧を取得
   useEffect(() => {
@@ -232,7 +236,7 @@ export const CameraRegisterPanel: React.FC<CameraRegisterPanelProps> = ({
               </span>
               <button
                 type="button"
-                onClick={onClearSelectedLocation}
+                onClick={clearSelectedLocationInputs}
                 className="text-slate-600 hover:text-slate-800"
               >
                 クリア

--- a/frontend/src/shared/types/index.ts
+++ b/frontend/src/shared/types/index.ts
@@ -4,6 +4,10 @@ export type AlertLevel = 'critical' | 'warning' | 'caution' | 'low';
 export type UploadStatus = 'pending' | 'processing' | 'completed' | 'failed';
 export type FileType = 'video' | 'image';
 export type DisplayMode = 'national' | 'nearby';
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
 
 // カメラ
 export interface Camera {

--- a/frontend/src/widgets/map/ui/MapView.tsx
+++ b/frontend/src/widgets/map/ui/MapView.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-leaflet';
 import type { LatLngBoundsExpression } from 'leaflet';
 import { getSightings, getFullImageUrl } from '@/shared/api';
-import type { DisplayMode, Sighting } from '@/shared/types';
+import type { DisplayMode, LatLng, Sighting } from '@/shared/types';
 import { alertLevelLabels, alertLevelEmojis } from '@/shared/types';
 import { getAlertColor, getMarkerRadius, formatConfidence, formatDateTime } from '@/shared/lib/utils';
 import { ImageModal } from '@/shared/ui';
@@ -29,7 +29,6 @@ const NEARBY_ZOOM = 12;
 const NEARBY_RADIUS_KM = 20;
 
 type LocationStatus = 'idle' | 'requesting' | 'granted' | 'manual';
-type LatLng = { lat: number; lng: number };
 
 interface MapViewProps {
   onSightingSelect?: (sighting: Sighting) => void;


### PR DESCRIPTION
## Summary
- lift camera placement state up to `HomePage` so map and register panel stay in sync
- extend `CameraRegisterPanel` with placement controls, auto-population from map selection, and reset logic on submit
- hook `MapView` into placement mode with click handling feedback marker and banner

## Testing
- Not run (not requested)